### PR TITLE
Added paint reloading options

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
       <div>
         <label for="penmode">Painting/Drawing Mode:</label>
         <select id="penmode">
-          <option value="0">Default (Brush, Water & Paint)</option>
+          <option value="0">Default (Brush, Water &amp; Paint)</option>
           <option value="1">Water Only (No Paint: Buddha Board)</option>
           <option value="2">Paint Only (No Water: Non-watercolors)</option>
           <option value="3">No Water or Paint (Pen/Pencil mode)</option>
@@ -116,12 +116,6 @@
       </div>
 
       <hr>
-
-      <div>
-        <label for="maxpaintdistance">Refill Distance:</label>
-        <input type="range" title="Move left to get paint more often, right to get paint less often" id="maxpaintdistance" min="500" max="20000" />
-        <aside>The distance for the brush to paint on the paper before it should go get more water/paint on the brush. Default is <b>48cm / 19in</b>.</aside>
-      </div>
 
       <div>
         <label for="strokeprecision">Stroke Precision:</label>
@@ -148,6 +142,34 @@
         </select>
         <aside>The distance factor to move the brush beyond when lifting to make up for brush bend. Default is <b>5mm</b>.</aside>
       </div>
+    </fieldset>
+
+    <fieldset class="paintreloading">
+        <legend>Paint Reloading</legend>
+        <aside>Choose when and how to go get more water/paint on the brush while painting with brushes.</aside>
+        </br>
+        <label for="reloadwhen">Reload when:</label>
+        <select id="reloadwhen">
+            <option value="0">After a certain distance</option>
+            <option value="1">After each path</option>
+        </select>
+        <aside>Reload after a certain distance or after each path. Using distance is more efficient, but causes interrupted paths. After each path is slower, but makes continuous strokes. Default is <b>After a certain distance</b>.</aside>
+        </br>
+        <label for="reloadhow">Reload how:</label>
+        <select id="reloadhow">
+            <option value="0">Full reload</option>
+            <option value="1">Single dip (1 water &plus; 1 paint)</option>
+            <option value="2">Single dip (just paint)</option>
+            <option value="3">Double dip (1 water &plus; 2 paint)</option>
+            <option value="4">Double dip (just paint)</option>
+        </select>
+        <aside>Reload by doing a full reload, single or double dips, with or without water. Use a full reload if using long distance reloads or lots of long paths. Dipping is best for short distance reloads or short paths. Default is <b>Full reload</b>.</aside>
+        <hr>
+        <div>
+            <label for="maxpaintdistance">Refill Distance:</label>
+            <input type="range" title="Move left to get paint more often, right to get paint less often" id="maxpaintdistance" min="500" max="20000" />
+            <aside>If using distance, this is how far it should paint on the paper before reloading. Default is <b>48cm / 19in</b>.</aside>
+        </div>
     </fieldset>
 
     <fieldset>

--- a/resources/main.js
+++ b/resources/main.js
@@ -540,7 +540,9 @@ function loadSettings() {
     tsprunnertype: 'OPT',
     strokeprecision: 6,
     manualpaintenable: 0,
-    gapconnect: 1
+    gapconnect: 1,
+    reloadwhen: 0,
+    reloadhow: 0
   };
 
   // Are there existing settings from a previous run? Mesh them into the defaults

--- a/resources/scripts/cncserver.client.commander.js
+++ b/resources/scripts/cncserver.client.commander.js
@@ -40,11 +40,43 @@ cncserver.cmd = {
 
       // Check for paint refill
       if (!cncserver.state.process.paused) {
-        if (cncserver.state.pen.distanceCounter > robopaint.settings.maxpaintdistance) {
+          // Check if using reload after distance, and if we've passed the max
+          if ( (robopaint.settings.reloadwhen == 0) && (cncserver.state.pen.distanceCounter > robopaint.settings.maxpaintdistance) ) {
           var returnPoint = returnPoints[returnPoints.length-1] ? returnPoints[returnPoints.length-1] : lastPoint;
+              
+          ////////////////////////////////////////////////////
+          // TODO: this switch should be implemented here!
+          ////////////////////////////////////////////////////
+          /*
+           switch (robotpaint.settings.reloadhow) {
+           case 0:
+           run('getpaintfull');
+           break;
+           case 1:
+           run('getwaterpaintdip');
+           break;
+           case 2:
+           run('getpaintdip');
+           break;
+           case 3:
+           run('getwaterpaintdoubledip');
+           break;
+           case 4:
+           run('getpaintdoubledip');
+           break;
+           default:
+           run('getpaintfull');
+           break;
+           }
+           */
+          ////////////////////////////////////////////////////
+          // instead of the following
+          ////////////////////////////////////////////////////
+
           cncserver.wcb.getMorePaint(returnPoint, function(){
             cncserver.api.pen.down(cncserver.cmd.executeNext);
           });
+              
         } else {
           // Execute next command
           cncserver.cmd.executeNext();
@@ -101,6 +133,17 @@ cncserver.cmd = {
       case "custom":
         cncserver.cmd.cb();
         if (next[1]) next[1](); // Run custom passed callback
+        break;
+      case "getpaintfull":
+        cncserver.wcb.getMorePaint(next[1],cncserver.cmd.cb);
+        break;
+      case "getwaterpaintdip":
+      case "getwaterpaintdoubledip":
+        // TODO: water + paint dips
+        break;
+      case "getpaintdip":
+      case "getpaintdoubledip":
+        // TODO: just paint dip
         break;
       default:
         console.debug('Queue shortcut not found:' + next[0]);

--- a/resources/scripts/cncserver.client.paths.js
+++ b/resources/scripts/cncserver.client.paths.js
@@ -212,10 +212,39 @@ cncserver.paths = {
                 var seg = $path[0].pathSegList.getItem(checkSeg);
                 if (seg.pathSegTypeAsLetter.toLowerCase() === "m") {
                   subPathCount++;
-                  run('status', 'Drawing subpath #' + subPathCount);
-                  run('up');
-                  run('move', p);
-                  run('down');
+                  if (options.reloadwhen == 1) {
+                    // reload after each path (now)
+                    run('status', 'Getting paint then drawing subpath #' + subPathCount);
+                    run('up');
+                    switch (options.reloadhow) {
+                        case 0:
+                            run('getpaintfull');
+                            break;
+                        case 1:
+                            run('getwaterpaintdip');
+                            break;
+                        case 2:
+                            run('getpaintdip');
+                            break;
+                        case 3:
+                            run('getwaterpaintdoubledip');
+                            break;
+                        case 4:
+                            run('getpaintdoubledip');
+                            break;
+                        default:
+                            run('getpaintfull');
+                            break;
+                    }
+                    run('move', p);
+                    run('down');
+                  } else {
+                    // reload after distance
+                    run('status', 'Drawing subpath #' + subPathCount);
+                    run('up');
+                    run('move', p);
+                    run('down');
+                  }
                   break;
                 }
               }


### PR DESCRIPTION
Added settings, UI, and logic to reload paint either after distance or after each path. 

TO DO: implement dip reload methods.

Ideally, the paint different paint reload method switches (full/dip) should be refactored into getMorePaint, but the nesting/logic there was beyond me.
