### PR TITLE
Fix globe icon location for language select menu

### DIFF
--- a/resources/main.settings.inc.html
+++ b/resources/main.settings.inc.html
@@ -1,9 +1,9 @@
 <button id="settings-done" class="normal" data-i18n="[title]settings.buttons.done.hover;settings.buttons.done.title">settings.buttons.done.title</button>
 <button id="settings-reset" class="normal" data-i18n="[title]settings.buttons.reset.hover;settings.buttons.reset.title">settings.buttons.reset.title</button>
-<img id="langIcon" src="images/icon_lang.png"/>
 <h2 data-i18n>nav.toolbar.settings</h2>
-<select id="lang"> </select>
-
+<div id="lang-wrapper">
+  <select id="lang"> </select>
+</div>
 
 <ul class="tabs">
   <li><a href="#settings-output" data-i18n>settings.tabs.output</a></li>

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -743,16 +743,18 @@ body.home div.options button.normal {
   margin-top: -6px;
 }
 
-#langIcon {
+#lang-wrapper {
   position: absolute;
-  right: 11em;
-  top: 1.5em;
+  right: 8.4em;
+  top: 1.6em;
+  background-image: url('images/icon_lang.png');
+  background-repeat: no-repeat;
+  padding-left: 1.7em;
+  background-position: left center;
+  height: 20px;
 }
 
 #lang {
-  position: absolute;
-  right: 14.7em;
-  top: 1.6em;
 }
 
 #settings-done {


### PR DESCRIPTION
This wraps a div around the language selection menu and puts the globe
icon to the left of the menu.
