### PR TITLE
[WIP] Mode Translations

### DIFF
--- a/resources/i18n/robopaint.en-US.json
+++ b/resources/i18n/robopaint.en-US.json
@@ -6,9 +6,29 @@
     "release": "0.9.2"
   },
   "common": {
-    "pause": "Pause",
-    "resume": "Resume",
-    "stop": "Stop",
+    "implement": {
+      "brush": "Brush",
+      "pen": "Pen"
+    },
+    "action": {
+      "park":"Park Home",
+      "disable":"Unlock Motors",
+      "pause": "Pause",
+      "resume": "Resume",
+      "stop": "Stop",
+      "start":"Start",
+      "cancel":"Cancel",
+      
+      "brush": {
+        "raise": "Raise Brush",
+        "lower": "Lower Brush",
+        "wash": "Wash Brush"
+      },
+      "pen": {
+        "raise": "Raise Pen",
+        "lower": "Lower Pen"
+      }
+    },
     "time": {
       "ms": "ms",
       "sec": "sec",

--- a/resources/main.html
+++ b/resources/main.html
@@ -55,7 +55,7 @@
     </svg>
     <fieldset id="details">
       <legend data-i18n>remoteprint.details.title</legend>
-      <button disabled="disabled" id="pause" data-i18n>common.pause</button>
+      <button disabled="disabled" id="pause" data-i18n>common.action.pause</button>
       <div id="statusmessage"></div>
       <progress title="Current progress" max="100" value="0"></progress>
       <button class="normal cancel" data-i18n="[title]remoteprint.details.exit.title;remoteprint.details.exit.text">remoteprint.details.exit.text</button>

--- a/resources/main.js
+++ b/resources/main.js
@@ -697,18 +697,20 @@ function loadAllModes(){
   });
 
   // Move through all approved modes based on mode weight and add DOM
+
   $('nav').append($('<table>').append($('<tr>')));
   for(var i in order) {
     var m = modes[order[i]];
     // Add the nav bubble
+    var i18nStr = "modes." + m.name + ".info.";
     $('nav table tr').prepend(
       $('<td>').append(
         $('<a>')
           .attr('href', m.main)
           .attr('id', m.name)
-          .attr('title', m.description)
+          .attr('title', robopaint.t(i18nStr + 'description'))
           .css('display', (m.core ? 'block' : 'none'))
-          .text(m.word)
+          .text(robopaint.t(i18nStr + 'word'))
       )
     );
 
@@ -719,16 +721,16 @@ function loadAllModes(){
         .attr('id', 'bar-' + m.name)
          // TODO: Add support for better icons
         .addClass('mode tipped ' + m.icon + (m.core ? '' : ' hidden') )
-        .attr('title', m.description)
+        .attr('title', robopaint.t(i18nStr + 'description'))
         .html('&nbsp;')
     );
 
     // Add the non-core settings checkbox for enabling
     if (!m.core) {
       $('fieldset.advanced-modes aside:first').after($('<div>').append(
-        $('<label>').attr('for', m.name + 'modeenable').text(m.title),
+        $('<label>').attr('for', m.name + 'modeenable').text(robopaint.t(i18nStr + 'title')),
         $('<input>').attr({type: 'checkbox', id: m.name + 'modeenable'}),
-        $('<aside>').text(m.detail)
+        $('<aside>').text(robopaint.t(i18nStr + 'detail'))
       ));
     }
   }

--- a/resources/main.js
+++ b/resources/main.js
@@ -519,6 +519,7 @@ function fadeInWindow() {
     $subwindow.hide().css('top', barHeight).fadeIn('fast');
   }
   subWin = $subwindow[0].contentWindow;
+  $('[data-i18n]', $subwindow.contents()).i18n();
 }
 
 

--- a/resources/main.js
+++ b/resources/main.js
@@ -519,7 +519,11 @@ function fadeInWindow() {
     $subwindow.hide().css('top', barHeight).fadeIn('fast');
   }
   subWin = $subwindow[0].contentWindow;
+  if (appMode == 'edit') {
+    translateEditMode();
+  }
   $('[data-i18n]', $subwindow.contents()).i18n();
+
 }
 
 

--- a/resources/modes/edit/i18n/edit.en-US.json
+++ b/resources/modes/edit/i18n/edit.en-US.json
@@ -9,6 +9,49 @@
     "title": "",
     "detail": "",
     "word": "Create"
+  },
+  "menu": {
+    "file": {
+      "title": "File",
+      "new": "New Document",
+      "open": "Open SVG...",
+      "import": "Import Image...",
+      "save": "Save Image..."
+    },
+    "edit": {
+      "title": "Edit",
+      "undo": "Undo",
+      "redo": "Redo",
+      "cut": "Cut",
+      "copy": "Copy",
+      "paste": "Paste",
+      "dupe": "Duplicate",
+      "del": "Delete"
+    },
+    "object": {
+      "title": "Object"
+    },
+    "view": {
+      "title": "View"
+    }
+  },
+  
+  "shortcuts": {
+    "ctrls": "Ctrl+S!",
+    "ctrlz": "Ctrl+Z",
+    "ctrly": "Ctrl+Y",
+    "ctrlx": "Ctrl+X",
+    "ctrlc": "Ctrl+C",
+    "ctrlv": "Ctrl+V",
+    "ctrld": "Ctrl+D",
+    
+    "ctrldel": "Ctrl+⌫",
+    "ctrls": "Ctrl+S",
+    "ctrls": "Ctrl+S",
+    "ctrls": "Ctrl+S",
+    "ctrls": "Ctrl+S",
+    "ctrls": "Ctrl+S",
+    "ctrls": "Ctrl+S"
   }
 }
   

--- a/resources/modes/edit/i18n/edit.en-US.json
+++ b/resources/modes/edit/i18n/edit.en-US.json
@@ -1,0 +1,15 @@
+{
+  "_meta": {
+    "creator": "rogerfachini",
+    "target": "en-US",
+    "release": "0.9.5"
+  },
+  "info":{
+    "description": "Open, resize, and edit existing vector artwork.",
+    "title": "",
+    "detail": "",
+    "word": "Create"
+  }
+}
+  
+  

--- a/resources/modes/edit/i18n/edit.en.json
+++ b/resources/modes/edit/i18n/edit.en.json
@@ -1,7 +1,0 @@
-{
-  "_meta": {
-    "creator": "techninja",
-    "target": "en-us",
-    "release": "0.8.5"
-  }
-}

--- a/resources/modes/edit/package.json
+++ b/resources/modes/edit/package.json
@@ -4,9 +4,7 @@
   "type": "robopaint_mode",
   "icon": "icon-edit",
   "weight": -5,
-  "word": "Create",
   "core": true,
-  "description": "Open, resize, and edit existing vector artwork.",
   "main": "method-editor/editor/index.html",
   "author": "techninja",
   "license": "MIT"

--- a/resources/modes/edit/translateDOM.json
+++ b/resources/modes/edit/translateDOM.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "creator": "rogerfachini",
+    "release": "0.9.5"
+  },
+  "DOM": [
+    {".menu_title:eq(1)": "modes.edit.menu.file.title"},
+    {".menu_title:eq(2)": "modes.edit.menu.edit.title"},
+    {".menu_title:eq(3)": "modes.edit.menu.object.title"},
+    {".menu_title:eq(4)": "modes.edit.menu.view.title"},
+    
+    {"#tool_clear.menu_item": "modes.edit.menu.file.new"},
+    {"#tool_open.menu_item": "modes.edit.menu.file.open"},
+    {"#tool_import.menu_item": "modes.edit.menu.file.import"},
+    {"#tool_save.menu_item": "modes.edit.menu.file.save"} ,
+    {"#tool_save .shortcut": "modes.edit.shortcuts.ctrls"},
+    
+    {"#tool_undo.menu_item": "modes.edit.menu.edit.undo"},
+    {"#tool_undo .shortcut": "modes.edit.shortcuts.ctrlz"}, 
+    {"#tool_redo.menu_item": "modes.edit.menu.edit.redo"},
+    {"#tool_redo .shortcut": "modes.edit.shortcuts.ctrly"},
+    {"#tool_cut.menu_item": "modes.edit.menu.edit.cut"},
+    {"#tool_cut .shortcut": "modes.edit.shortcuts.ctrlx"},
+    {"#tool_copy.menu_item": "modes.edit.menu.edit.cut"},
+    {"#tool_copy .shortcut": "modes.edit.shortcuts.ctrlc"},
+    {"#tool_paste.menu_item": "modes.edit.menu.edit.cut"},
+    {"#tool_paste .shortcut": "modes.edit.shortcuts.ctrlv"},
+    {"#tool_clone.menu_item": "modes.edit.menu.edit.cut"},
+    {"#tool_clone .shortcut": "modes.edit.shortcuts.ctrld"},
+    {"#tool_delete.menu_item": "modes.edit.menu.edit.cut"},
+    {"#tool_delete .shortcut": "modes.edit.shortcuts.ctrldel"}
+    
+  ]
+                   
+  
+}

--- a/resources/modes/example/i18n/example.en-US.json
+++ b/resources/modes/example/i18n/example.en-US.json
@@ -1,0 +1,13 @@
+{
+  "_meta": {
+    "creator": "rogerfachini",
+    "target": "en-US",
+    "release": "0.9.5"
+  },
+  "info":{
+    "description": "An example mode for rendering text that can be sent to other modes.",
+    "title": "Example Text Rendering Mode",
+    "detail": "A simple example RoboPaint mode to show how to build your own mode.",
+    "word": "Text"
+  }
+}

--- a/resources/modes/example/i18n/example.en.json
+++ b/resources/modes/example/i18n/example.en.json
@@ -1,7 +1,0 @@
-{
-  "_meta": {
-    "creator": "techninja",
-    "target": "en-us",
-    "release": "0.8.5"
-  }
-}

--- a/resources/modes/example/package.json
+++ b/resources/modes/example/package.json
@@ -4,11 +4,7 @@
   "type": "robopaint_mode",
   "icon": "icon-font",
   "weight": 2,
-  "word": "Text",
   "core": false,
-  "description": "An example mode for rendering text that can be sent to other modes.",
-  "title": "Example Text Rendering Mode",
-  "detail": "A simple example RoboPaint mode to show how to build your own mode.",
   "main": "example.html",
   "author": "techninja",
   "license": "MIT"

--- a/resources/modes/manual/i18n/manual.en-US.json
+++ b/resources/modes/manual/i18n/manual.en-US.json
@@ -1,0 +1,13 @@
+{
+  "_meta": {
+    "creator": "rogerfachini",
+    "target": "en-US",
+    "release": "0.9.5"
+  },
+  "info":{
+    "description": "Manual Mode: Customize your print",
+    "title": "Manual Paint",
+    "detail": "Like Auto-paint, but allows for more control over what elements are painted, and a number of other options.",
+    "word": "Manual"
+  }
+}

--- a/resources/modes/manual/i18n/manual.en.json
+++ b/resources/modes/manual/i18n/manual.en.json
@@ -1,7 +1,0 @@
-{
-  "_meta": {
-    "creator": "techninja",
-    "target": "en-us",
-    "release": "0.8.5"
-  }
-}

--- a/resources/modes/manual/package.json
+++ b/resources/modes/manual/package.json
@@ -4,11 +4,7 @@
   "type": "robopaint_mode",
   "icon": "icon-picture-1",
   "weight": 1,
-  "word": "Manual",
   "core": false,
-  "description": "Manual Mode: Customize your print",
-  "title": "Manual Paint",
-  "detail": "Like Auto-paint, but allows for more control over what elements are painted, and a number of other options.",
   "main": "manual.html",
   "author": "techninja",
   "license": "MIT"

--- a/resources/modes/print/i18n/print.en-US.json
+++ b/resources/modes/print/i18n/print.en-US.json
@@ -15,19 +15,6 @@
    "title":"Auto-paint",
    "subtitle":"Control",
    
-   "buttons":{
-     "pause":"Pause",
-     "start":"Start",
-     "cancel":"Cancel Print",
-     "pen":"Brush",
-     "park":"Park Home",
-     "disable":"Unlock Motors",
-     "resume":"Resume",
-     "raise":"Raise",
-     "lower":"Lower"
-     
-   },
-   
    "info":{
      "pause":"Click to start painting your picture!",
      "cancel":"Cancel current print job.",

--- a/resources/modes/print/i18n/print.en-US.json
+++ b/resources/modes/print/i18n/print.en-US.json
@@ -1,8 +1,61 @@
 {
   "_meta": {
-    "creator": "techninja",
+    "creator": "rogerfachini",
     "target": "en-us",
-    "release": "0.8.5"
-  }
-
+    "release": "0.9.5"
+  },
+  "info":{
+    "description": "Painting Mode: Print your drawing!",
+    "title": "Automatic Paint",
+    "detail": "Automatically paint a given well formed SVG file.",
+    "word": "Print"
+  },
+  
+ "control":{
+   "title":"Auto-paint",
+   "subtitle":"Control",
+   
+   "buttons":{
+     "pause":"Pause",
+     "start":"Start",
+     "cancel":"Cancel Print",
+     "pen":"Brush",
+     "park":"Park Home",
+     "disable":"Unlock Motors",
+     "resume":"Resume",
+     "raise":"Raise",
+     "lower":"Lower"
+     
+   },
+   
+   "info":{
+     "pause":"Click to start painting your picture!",
+     "cancel":"Cancel current print job.",
+     "park":"Move the carriage back to the home position",
+     "disable":"Raise brush and Unlock (disable) stepper motors, so that you can move the carriage by hand.",
+     "confirm":"Are you sure you want to cancel the current print job and reset (for example, to start a new print job)?"
+   },
+   "status":{
+     "title":"Status",
+     "info":"Current progress",
+     "ready": "Click to start painting your picture!",
+     "pause": "Click to stop current operations",
+     "resume": "Click to resume operations",
+     "wait": "Please wait while executed processes complete...",
+     
+     "cncserver":{
+       "pausing":"Pausing current process...",
+       "paused":"Paused. Click resume to continue.",
+       "resume":"Resuming current process...",
+       "drawResume":"Drawing resumed...",
+       
+       "parkStart":"Parking brush...",
+       "parkSucceed": "Brush parked succesfully",
+       "parkFail": "Can't Park, already parked",
+       "motorUnlock":"Unlocking motors...",
+       "unlockNotice": "'Motors unlocked! Place in home corner when done'"
+     }
+     
+   }
+ }
 }

--- a/resources/modes/print/i18n/print.en-US.json
+++ b/resources/modes/print/i18n/print.en-US.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "creator": "rogerfachini",
-    "target": "en-us",
+    "target": "en-US",
     "release": "0.9.5"
   },
   "info":{

--- a/resources/modes/print/package.json
+++ b/resources/modes/print/package.json
@@ -4,11 +4,7 @@
   "type": "robopaint_mode",
   "icon": "icon-print",
   "weight": 0,
-  "word": "Print",
   "core": true,
-  "description": "Painting Mode: Print your drawing!",
-  "title": "Automatic Paint",
-  "detail": "Automatically paint a given well formed SVG file.",
   "main": "print.html",
   "author": "techninja",
   "license": "MIT"

--- a/resources/modes/print/print.css
+++ b/resources/modes/print/print.css
@@ -313,15 +313,6 @@ body.print-auto #buttons button.normal {
   width: 190px;
 }
 
-/* Handle simple button text changes via class, tricksy CSS hobbits! */
-#pen.up:before {
-  content: "modes.print.control.buttons.raise";
-}
-
-#pen.down:before {
-  content: "modes.print.control.buttons.lower ";
-}
-
 /* Status Specific */
 #status {
   text-align: center;

--- a/resources/modes/print/print.css
+++ b/resources/modes/print/print.css
@@ -315,11 +315,11 @@ body.print-auto #buttons button.normal {
 
 /* Handle simple button text changes via class, tricksy CSS hobbits! */
 #pen.up:before {
-  content: "Raise ";
+  content: "modes.print.control.buttons.raise";
 }
 
 #pen.down:before {
-  content: "Lower ";
+  content: "modes.print.control.buttons.lower ";
 }
 
 /* Status Specific */

--- a/resources/modes/print/print.html
+++ b/resources/modes/print/print.html
@@ -9,19 +9,19 @@
 <body class="print print-auto">
 
 <fieldset id="control">
-  <legend>modes.print.control.title</legend>
+  <legend data-i18n>modes.print.control.title</legend>
 
   <fieldset id="buttons">
-    <legend>modes.print.control.subtitle</legend>
-    <button id="pause" class="ready" data-i18n="[title]modes.print.control.info.pause">modes.print.control.buttons.start</button>
-    <button id="cancel" disabled="disabled" data-i18n="[title]modes.print.control.info.cancel">modes.print.control.buttons.cancel</button>
-    <button id="pen" class="normal">modes.print.control.buttons.pen</button>
-    <button id="park" class="normal" data-i18n="[title]modes.print.control.info.park">modes.print.control.buttons.park</button>
-    <button id="disable" class="normal" data-i18n="[title]modes.print.control.info.disable">modes.print.control.buttons.disable</button>
+    <legend data-i18n>modes.print.control.subtitle</legend>
+    <button id="pause" class="ready" data-i18n="[title]modes.print.control.info.pause;common.action.start"></button>
+    <button id="cancel" disabled="disabled" data-i18n="[title]modes.print.control.info.cancel;common.action.cancel"></button>
+    <button id="pen" class="normal" data-i18n="common.action.pen"></button>
+    <button id="park" class="normal" data-i18n="[title]modes.print.control.info.park;common.action.park"></button>
+    <button id="disable" class="normal" data-i18n="[title]modes.print.control.info.disable;common.action.disable"></button>
   </fieldset>
 
   <fieldset id="status">
-    <legend>modes.print.control.status.title</legend>
+    <legend data-i18n>modes.print.control.status.title</legend>
     <div id="statusmessage"></div>
     <div class="progress-wrapper">
       <progress data-i18n="[title]modes.print.control.status.info" max="100" value="0"></progress>
@@ -67,4 +67,5 @@
 
 </body>
 </html>
+
 

--- a/resources/modes/print/print.html
+++ b/resources/modes/print/print.html
@@ -9,22 +9,22 @@
 <body class="print print-auto">
 
 <fieldset id="control">
-  <legend>Auto-paint</legend>
+  <legend>modes.print.control.title</legend>
 
   <fieldset id="buttons">
-    <legend>Control</legend>
-    <button id="pause" class="ready" title="Click to start painting your picture!">Start</button>
-    <button id="cancel" disabled="disabled" title="Cancel current print job.">Cancel Print</button>
-    <button id="pen" class="normal">Brush</button>
-    <button id="park" class="normal" title="Move the carriage back to the home position">Park Home</button>
-    <button id="disable" class="normal" title="Raise brush and Unlock (disable) stepper motors, so that you can move the carriage by hand.">Unlock Motors</button>
+    <legend>modes.print.control.subtitle</legend>
+    <button id="pause" class="ready" data-i18n="[title]modes.print.control.info.pause">modes.print.control.buttons.start</button>
+    <button id="cancel" disabled="disabled" data-i18n="[title]modes.print.control.info.cancel">modes.print.control.buttons.cancel</button>
+    <button id="pen" class="normal">modes.print.control.buttons.pen</button>
+    <button id="park" class="normal" data-i18n="[title]modes.print.control.info.park">modes.print.control.buttons.park</button>
+    <button id="disable" class="normal" data-i18n="[title]modes.print.control.info.disable">modes.print.control.buttons.disable</button>
   </fieldset>
 
   <fieldset id="status">
-    <legend>Status</legend>
+    <legend>modes.print.control.status.title</legend>
     <div id="statusmessage"></div>
     <div class="progress-wrapper">
-      <progress title="Current progress" max="100" value="0"></progress>
+      <progress data-i18n="[title]modes.print.control.status.info" max="100" value="0"></progress>
     </div>
   </fieldset>
 </fieldset>

--- a/resources/modes/print/print.js
+++ b/resources/modes/print/print.js
@@ -45,7 +45,7 @@ $(function() {
   robopaint.socket.on('callback update', function(callback){
     switch(callback.name) {
       case 'autopaintcomplete': // Should happen when we're completely done
-        $('#pause').attr('class', 'ready').attr('title', bufferStateText.ready).text('modes.print.control.buttons.start');
+        $('#pause').attr('class', 'ready').attr('title', bufferStateText.ready).text('common.action.start');
         $('#buttons button.normal').prop('disabled', false); // Enable options
         $('#cancel').prop('disabled', true); // Disable the cancel print button
         break;
@@ -75,7 +75,7 @@ $(function() {
 
     // Cancel Print
     $('#cancel').click(function(){
-      var cancelPrint = confirm("modes.print.control.info.confirm");
+      var cancelPrint = confirm(robopaint.t("modes.print.control.info.confirm"));
       if (cancelPrint) {
         unBindEvents(function(){
           robopaint.switchMode('home', function(){
@@ -91,7 +91,10 @@ $(function() {
 
       // With nothing in the queue, start autopaint!
       if (cncserver.state.buffer.length === 0) {
-        $('#pause').removeClass('ready').attr('title', bufferStateText.pause).text('conrol.buttons.pause');
+        $('#pause')
+          .removeClass('ready')
+          .attr('title', bufferStateText.pause)
+          .text(robopaint.t('common.action.pause'));
         $('#buttons button.normal').prop('disabled', true); // Disable options
         $('#cancel').prop('disabled', false); // Enable the cancel print button
 
@@ -112,15 +115,21 @@ $(function() {
           robopaint.cncserver.api.buffer.pause(function(){
             cncserver.wcb.status(bufferStateText.paused, 'complete');
             $('#buttons button.normal').prop('disabled', false); // Enable options
-            $('#pause').addClass('active').attr('title', bufferStateText.resume).text('modes.print.control.button.resume');
-            $('#pause').prop('disabled', false);
+            $('#pause')
+              .addClass('active')
+              .attr('title', bufferStateText.resume)
+              .prop('disabled', false)
+              .text(robopaint.t("modes.print.control.button.resume"));
           });
         } else {
           // Resuming ===============
           $('#buttons button.normal').prop('disabled', true); // Disable options
           cncserver.wcb.status(bufferStateText.statusResume);
           robopaint.cncserver.api.buffer.resume(function(){
-            $('#pause').removeClass('active').attr('title', bufferStateText.pause).text('modes.print.control.button.pause');
+            $('#pause')
+              .removeClass('active')
+              .attr('title', bufferStateText.pause)
+              .text(robopaint.t('modes.print.control.button.pause'));
             cncserver.wcb.status(bufferStateText.drawResume, true);
           });
         }

--- a/resources/scripts/main.api.js
+++ b/resources/scripts/main.api.js
@@ -372,7 +372,7 @@ function setRemotePrintWindow(tryOpen, force) {
   if (toggle) {
     // Reset inputs
     $('#remoteprint-window progress').val(0);
-    $('#remoteprint-window button#pause').prop('disabled', true).text(robopaint.t('common.pause'));
+    $('#remoteprint-window button#pause').prop('disabled', true).text(robopaint.t('common.action.pause'));
     $('#remoteprint-window #statusmessage').text(robopaint.t('remoteprint.api.wait'));
 
     $('#remoteprint-window').fadeIn('slow');

--- a/resources/scripts/robopaint.mode.svg.js
+++ b/resources/scripts/robopaint.mode.svg.js
@@ -139,11 +139,12 @@ $(function() {
     //}
 
     // Update button text/state
-    var toState = 'up';
+    // TODO: change implement type <brush> based on actual implement selected!
+    var key = 'common.action.brush.raise';
     if (cncserver.state.actualPen.state == "up" || cncserver.state.actualPen.state == 0){
-      toState = 'down';
+      key = 'common.action.brush.lower';
     }
-    $('#pen').attr('class','normal ' + toState);
+    $('#pen').text(robopaint.t(key));
   }
 
   // Handle buffer status messages

--- a/resources/translate.js
+++ b/resources/translate.js
@@ -35,6 +35,8 @@ function translatePage() {
       resources[data['_meta'].target] = { translation: data};
       //Create empty colorset key
       resources[data['_meta'].target].translation['colorsets'] = {};
+      //Create empty modes key
+      resources[data['_meta'].target].translation['modes'] = {};
 
       i += 1;
     } catch(e) {
@@ -76,6 +78,26 @@ function translatePage() {
   } catch(e) {
     // Catch and report errors to the console
     console.error('Bad or missing Colorset translation file for: ' + folder, e); }
+  });
+
+  //Load all Mode translation files
+  fs.readdirSync('resources/modes/').forEach(function(folder) {
+    try {
+      // Ignore files that have extentions (we only want directories).
+      if (folder.indexOf(".") == -1) {
+       // Create a full path to the directory containing this colorset's i18n
+       // files.
+        var fullPath = 'resources/modes/' + folder + '/i18n/';
+        //  Iterate over language files in mode's i18n folder
+        fs.readdirSync(fullPath).forEach(function(file) {
+          //  Add the data to the global i18n translation array
+          var data = JSON.parse(fs.readFileSync(fullPath + file , 'utf8'));
+          resources[data['_meta'].target].translation['modes'][folder] = data;
+        });
+       }
+  } catch(e) {
+    // Catch and report errors to the console
+    console.error('Bad or missing Mode translation file for: ' + folder, e); }
   });
 
   // Loop over every element in the current document scope that has a 'data-i18n' attribute that's empty
@@ -185,5 +207,6 @@ function updateLang() {
     $(this).html($(this).text().replace(/\*\*(\S(.*?\S)?)\*\*/gm, '<b>$1</b>'));
   });
 }
+
 
 

--- a/resources/translate.js
+++ b/resources/translate.js
@@ -209,4 +209,36 @@ function updateLang() {
 }
 
 
+/**
+ * Contains specific code to translating the 'Edit' mode, as the majority of that
+ * mode is method-draw, which is not made by us.
+ */
+function translateEditMode() {
+  var domFile = 'resources/modes/edit/translateDOM.json';
+  try {
+      var domData = JSON.parse(fs.readFileSync(domFile , 'utf8'));
+      console.debug(domData);
+      domData = domData['DOM'];
+      for (var i in domData) {
+        var obj = domData[i];
+        var key = Object.keys(obj)[0];
+
+
+        var DOM = $(key, window.$subwindow.contents());
+        console.debug(key + ' had '+ DOM.text());
+        var $children = DOM.children();
+
+        DOM.text(window.robopaint.t(obj[key]));
+        DOM.append($children);
+
+     }
+
+    } catch(e) {
+      console.error('Bad DOM location file (somehow):' + domFile, e);
+    }
+
+
+}
+
+
 


### PR DESCRIPTION
**NOTE:** In it's current state, this is not even close to being ready to pull yet, but this can serve as space for code-specific discussion and more commits from me (coming real soon)! General discussion and updates should probably be in #186, and code specific conversation can be here. 

The start of my work to get mode translation working, I changed the
print mode to actually have the respective translate text in a translate
file instead of in the code directly. List of changes:
- Static translate strings embedded in the HTML have been changed to
translate strings
- Dynamic translate strings (status messages) are translated and added
to an array at the beginning of the mode JS file. This array is
referenced instead of a translate string (keeping all major translate
strings in the same place)
- Added all strings to the existing print i18n mode file.

TODOs:
- Actually write the backend code to translate the strings in mode.
- Create base English translations from existing text in other modes.
- Create mode translations for other languages we support.