### PR TITLE
Fix small bug with markup parsing

### DIFF
--- a/resources/translate.js
+++ b/resources/translate.js
@@ -134,7 +134,19 @@ function translatePage() {
     $('[data-i18n]').i18n();
     setVersion();
   });
+markupParse();
 }
+
+/**
+ * DRY helper function for markup parsing
+ */
+
+function markupParse(){
+  //  Apply bold details to text.
+  $('aside').each(function(){
+    $(this).html($(this).text().replace(/\*\*(\S(.*?\S)?)\*\*/gm, '<b>$1</b>'));
+  });
+
 
 /**
  * DRY helper function to set the version text
@@ -180,10 +192,7 @@ function updateLang() {
 
   getColorsets(); // Reload and reparse colorsets
 
-  // Apply bolding to details text
-  $('aside').each(function(){
-    $(this).html($(this).text().replace(/\*\*(\S(.*?\S)?)\*\*/gm, '<b>$1</b>'));
-  });
+  markupParse();
 }
 
 


### PR DESCRIPTION
I fixed a very small bug where markup parsing would not work until you change the language. 

Note: Trying to get rid of extra useless commits by putting this in its own branch somehow ended up with additional commits. 
