### PR TITLE
Reload active mode with mode icon

### DIFF
--- a/resources/main.js
+++ b/resources/main.js
@@ -270,11 +270,6 @@ function bindMainControls() {
 
     var $target = $(e.target);
 
-    // Don't do anything if already selected
-    if ($target.is('.selected')) {
-      return false;
-    }
-
     targetMode = $target;
     checkModeClose(false, e.target.id.split('-')[1]);
   });
@@ -348,10 +343,6 @@ function bindMainControls() {
  *   The mode's machine name. NOTE: Does no sanity checks!
  */
 robopaint.switchMode = function(mode, callback) {
-  if (appMode == mode) { // Don't switch modes if already there
-    return;
-  }
-
   appMode = mode; // Set the new mode
 
   $target = $('a#bar-' + mode);

--- a/resources/styles/main.css
+++ b/resources/styles/main.css
@@ -315,7 +315,6 @@ body.home #bar a:hover.selected{
   background-color: rgb(92, 175, 255);
   border-top-left-radius: 0.5em;
   border-top-right-radius: 0.5em;
-  cursor: default;
 }
 
 #bar a.mode {


### PR DESCRIPTION
This will cause the currently active mode to be reloaded when its icon is clicked. This is very useful for developing modes as it makes it much easier to load any changes to the code.

Should this be added as an option in the settings?