### PR TITLE
Question: Pin cncserver dependency to current cncserver ?

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "stage": "development",
   "license": "MIT",
   "dependencies": {
-    "cncserver": "https://github.com/techninja/cncserver/tarball/master",
+    "cncserver": "techninja/cncserver#2a93a48c86e0bce5861c83b46c0bda6e5d63bcbb",
     "fs-plus": "^2.8.1"
   },
   "repository": {


### PR DESCRIPTION
This bit me when trying to reproduce the v0.9.5 tag for testing. Doing a 'npm install' from the v0.9.5 tag would pull the latest cncserver, which is not the one included in the v0.9.5 release package.

New to node & electron projects, though, so not sure what the convention is when creating releases. Should robopaint releases pin to specific dependency releases?