### PR TITLE
Fix problem in npm caused by use of `type` in `package.json`

### DIFF
--- a/MODES.README.md
+++ b/MODES.README.md
@@ -48,7 +48,7 @@ RoboPaint package.json dependency or through direct `npm install`.
 {
   "name": "robopaint-mode-example", // Universal namespace ID for NPM, should be in this format!
   "version": "0.8.0",
-  "type": "robopaint_mode", // If not equal to this, this package will be ignored.
+  "robopaint-type": "robopaint_mode", // If not equal to this, this package will be ignored.
   "main": "example.js",  // Used to inject your JS into the page at the correct time during preload. No need to include it in the HTML!
   "author": "techninja",
   "license": "MIT",

--- a/MODES.README.md
+++ b/MODES.README.md
@@ -48,7 +48,7 @@ RoboPaint package.json dependency or through direct `npm install`.
 {
   "name": "robopaint-mode-example", // Universal namespace ID for NPM, should be in this format!
   "version": "0.8.0",
-  "robopaint-type": "robopaint_mode", // If not equal to this, this package will be ignored.
+  "robopaint-type": "mode", // If not equal to this, this package will be ignored.
   "main": "example.js",  // Used to inject your JS into the page at the correct time during preload. No need to include it in the HTML!
   "author": "techninja",
   "license": "MIT",

--- a/resources/main.js
+++ b/resources/main.js
@@ -717,7 +717,7 @@ function loadAllModes(){
     }
 
     // This a good file? if so, lets make it ala mode!
-    if (package.robopaint-type === "robopaint_mode" && _.has(package.robopaint, 'index')) {
+    if (package.robopaint-type === "mode" && _.has(package.robopaint, 'index')) {
       // TODO: Add FS checks to see if its index file actually exists
       package.root = path.join(modesDir, modeDirs[i], '/');
       package.index = path.join(package.root, package.robopaint.index);

--- a/resources/main.js
+++ b/resources/main.js
@@ -717,7 +717,7 @@ function loadAllModes(){
     }
 
     // This a good file? if so, lets make it ala mode!
-    if (package.type === "robopaint_mode" && _.has(package.robopaint, 'index')) {
+    if (package.robopaint-type === "robopaint_mode" && _.has(package.robopaint, 'index')) {
       // TODO: Add FS checks to see if its index file actually exists
       package.root = path.join(modesDir, modeDirs[i], '/');
       package.index = path.join(package.root, package.robopaint.index);

--- a/resources/main.js
+++ b/resources/main.js
@@ -717,7 +717,7 @@ function loadAllModes(){
     }
 
     // This a good file? if so, lets make it ala mode!
-    if (package.robopaint-type === "mode" && _.has(package.robopaint, 'index')) {
+    if (package['robopaint-type'] === "mode" && _.has(package.robopaint, 'index')) {
       // TODO: Add FS checks to see if its index file actually exists
       package.root = path.join(modesDir, modeDirs[i], '/');
       package.index = path.join(package.root, package.robopaint.index);

--- a/resources/translate.js
+++ b/resources/translate.js
@@ -88,7 +88,7 @@ function initializeTranslation() {
         var p = require(fullPath + 'package.json');
 
         //  Iterate over language files in mode's i18n folder
-        if (p.robopaint-type === 'mode') {
+        if (p['robopaint-type'] === 'mode') {
           fs.readdirSync(fullPath + '_i18n/').forEach(function(file) {
             if (file.indexOf('.map.json') === -1) { // Don't use translation maps.
               //  Add the data to the global i18n translation array

--- a/resources/translate.js
+++ b/resources/translate.js
@@ -88,7 +88,7 @@ function initializeTranslation() {
         var p = require(fullPath + 'package.json');
 
         //  Iterate over language files in mode's i18n folder
-        if (p.robopaint-type === 'robopaint_mode') {
+        if (p.robopaint-type === 'mode') {
           fs.readdirSync(fullPath + '_i18n/').forEach(function(file) {
             if (file.indexOf('.map.json') === -1) { // Don't use translation maps.
               //  Add the data to the global i18n translation array

--- a/resources/translate.js
+++ b/resources/translate.js
@@ -88,7 +88,7 @@ function initializeTranslation() {
         var p = require(fullPath + 'package.json');
 
         //  Iterate over language files in mode's i18n folder
-        if (p.type === 'robopaint_mode') {
+        if (p.robopaint-type === 'robopaint_mode') {
           fs.readdirSync(fullPath + '_i18n/').forEach(function(file) {
             if (file.indexOf('.map.json') === -1) { // Don't use translation maps.
               //  Add the data to the global i18n translation array


### PR DESCRIPTION
In npm v3+ (v3.8.2 is currently the newest version) a change in the way packages are located results in the use of the `type` key in `package.json` breaking npm. This fixes this problem by changing `type` to `robopaint-type`.
More information on the change in npm can be found here.
https://gitter.im/evil-mad/robopaint?at=56ea48590055f8f35a83f07c