### PR TITLE
Tracing fix(es)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hersheytext": "^0.5.1",
     "i18next-client": "^1.10.2",
     "jquery": "^2.2.3",
-    "paper": "^0.9.24",
+    "paper": "^0.9.25",
     "qtip2": "^2.2.0",
     "request": "^2.65.0",
     "robopaint-mode-edit": "*",

--- a/resources/rp_modules/paper.auto.fill.js
+++ b/resources/rp_modules/paper.auto.fill.js
@@ -151,17 +151,25 @@ module.exports = function(paper) {
         if (!paper.utils.hasColor(path.fillColor)) {
           path.remove();
         } else {
-          path.closed = true;
-          path.data.color = snapColorID(path.fillColor, path.opacity);
-          path.data.name = path.name;
-          path.fillColor = snapColor(path.fillColor, path.opacity);
-          path.strokeWidth = 0;
-          path.strokeColor = null;
+          var data = {
+            color: snapColorID(path.fillColor, path.opacity),
+            name: path.name,
+            targetPath: path.data.targetPath,
+          };
 
           // Be sure to set the correct color/tool if given.
-          if (path.data.targetPath && settings.pathColor) {
-            path.data.color = settings.pathColor;
+          if (data.targetPath && settings.pathColor) {
+            data.color = settings.pathColor;
           }
+
+          // Bulk set path options.
+          paper.utils.setPathOption(path, {
+            closed: true,
+            data: data,
+            fillColor: snapColor(path.fillColor, path.opacity),
+            strokeWidth: 0,
+            strokeColor: null,
+          });
         }
       });
 

--- a/resources/rp_modules/paper.auto.fill.js
+++ b/resources/rp_modules/paper.auto.fill.js
@@ -754,6 +754,9 @@ module.exports = function(paper) {
     // Is this a compound path?
     if (p.children) {
       _.each(p.children, function(c, pathIndex) {
+        if (c.segments.length <= 1 && c.closed) {
+          c.closed = false;
+        }
         c.flatten(settings.flattenResolution);
         paths[pathIndex] = [];
         _.each(c.segments, function(s){

--- a/resources/rp_modules/paper.auto.fill.js
+++ b/resources/rp_modules/paper.auto.fill.js
@@ -597,6 +597,9 @@ module.exports = function(paper) {
           }
           if (type === 'zigsmooth' && cGroup) {
             cGroup.simplify();
+            if (cGroup.segments.length <= 1 && cGroup.closed) {
+              cGroup.closed = false;
+            }
             cGroup.flatten(settings.flattenResolution);
           }
 
@@ -618,6 +621,9 @@ module.exports = function(paper) {
           if (!p.contains(v.getPointAt(v.length/2)) || v.getIntersections(p).length > 3) {
             if (type === 'zigsmooth') {
               cGroup.simplify();
+              if (cGroup.segments.length <= 1 && cGroup.closed) {
+                cGroup.closed = false;
+              }
               cGroup.flatten(settings.flattenResolution);
             }
 

--- a/resources/rp_modules/paper.auto.stroke.js
+++ b/resources/rp_modules/paper.auto.stroke.js
@@ -127,24 +127,24 @@ module.exports = function(paper) {
         var doStroke = true; // Assume we're stroking the path
         switch(paper.utils.getPathColorType(path)) {
           case 1: // Type 1: Stroked filled shape
-            path.fillColor = snapColor(path.fillColor, path.opacity);
+            paper.utils.setPathOption(path, 'fillColor', snapColor(path.fillColor, path.opacity));
           case 2: // Type 2: Stroked non-filled shape
-            path.strokeColor = snapColor(path.strokeColor, path.opacity)
+            paper.utils.setPathOption(path, 'strokeColor', snapColor(path.strokeColor, path.opacity));
             break;
           case 3: // Type 3: Filled no stroke shape
-            path.fillColor = snapColor(path.fillColor, path.opacity);
+            paper.utils.setPathOption(path, 'fillColor', snapColor(path.fillColor, path.opacity));
             if (settings.strokeAllFilledPaths) {
-              path.strokeColor = snapColor(path.fillColor, path.opacity);
+              paper.utils.setPathOption(path, 'strokeColor', snapColor(path.fillColor, path.opacity));
             } else {
-              path.strokeWidth = 0; // Ensure it's ignored later
+              paper.utils.setPathOption(path, 'strokeWidth', 0); // Ensure it's ignored later
               doStroke = false;
             }
             break;
           case 4: // Type 4: No fill, no stroke shape (invisible)
             if (settings.strokeNoStrokePaths) {
-              path.strokeColor = snapColor(path.strokeColor, path.opacity)
+              paper.utils.setPathOption(path, 'strokeColor', snapColor(path.strokeColor, path.opacity));
             } else {
-              path.strokeWidth = 0; // Ensure it's ignored later
+              paper.utils.setPathOption(path, 'strokeWidth', 0); // Ensure it's ignored later
               doStroke = false;
             }
             break;
@@ -153,16 +153,21 @@ module.exports = function(paper) {
         // If we're actually stroking this path, make it visible with a stroke
         // width and add its length to the max for checking progress.
         if (doStroke) {
-          path.data.color = snapColorID(path.strokeColor, path.opacity);
-          path.data.name = path.name;
-          path.strokeWidth = settings.lineWidth;
-          maxLen += path.length;
-          path.originalOpacity = path.opacity;
+          var data = {
+            color: snapColorID(path.strokeColor, path.opacity),
+            name: path.name,
+            targetPath: path.data.targetPath,
+          };
 
           // Be sure to set the correct color/tool if given.
-          if (path.data.targetPath && settings.pathColor) {
-            path.data.color = settings.pathColor;
+          if (data.targetPath && settings.pathColor) {
+            data.color = settings.pathColor;
           }
+
+          paper.utils.setPathOption(path, 'data', data);
+          paper.utils.setPathOption(path, 'strokeWidth', settings.lineWidth);
+          path.originalOpacity = path.opacity;
+          maxLen += paper.utils.getPathLength(path);
         }
 
         // If only stroking one path, visually hide all the other paths.

--- a/resources/rp_modules/paper.auto.stroke.js
+++ b/resources/rp_modules/paper.auto.stroke.js
@@ -313,6 +313,12 @@ module.exports = function(paper) {
       // will cause closest intersection connection issues.
       var h = tmp.hitTest(testPoint);
 
+      // Apparently sometimes hitTest can return undefined, so we default it to
+      // an object in that case so we don't have any direct failure below.
+      if (_.isUndefined(h)) {
+        h = {};
+      }
+
       // Standard fill/stroke checking: if the hit result item is the same as
       // our current path, keep going!
       var continueStroke = (h.item === cPath);

--- a/resources/rp_modules/paper.auto.stroke.js
+++ b/resources/rp_modules/paper.auto.stroke.js
@@ -127,24 +127,40 @@ module.exports = function(paper) {
         var doStroke = true; // Assume we're stroking the path
         switch(paper.utils.getPathColorType(path)) {
           case 1: // Type 1: Stroked filled shape
-            paper.utils.setPathOption(path, 'fillColor', snapColor(path.fillColor, path.opacity));
+            paper.utils.setPathOption(path, {
+              fillColor: snapColor(path.fillColor, path.opacity)
+            });
+            /* falls through */
+
           case 2: // Type 2: Stroked non-filled shape
-            paper.utils.setPathOption(path, 'strokeColor', snapColor(path.strokeColor, path.opacity));
+            paper.utils.setPathOption(path, {
+              strokeColor: snapColor(path.strokeColor, path.opacity)
+            });
             break;
+
           case 3: // Type 3: Filled no stroke shape
-            paper.utils.setPathOption(path, 'fillColor', snapColor(path.fillColor, path.opacity));
+            paper.utils.setPathOption(path, {
+              fillColor: snapColor(path.fillColor, path.opacity)
+            });
             if (settings.strokeAllFilledPaths) {
-              paper.utils.setPathOption(path, 'strokeColor', snapColor(path.fillColor, path.opacity));
+              paper.utils.setPathOption(path, {
+                strokeColor: snapColor(path.fillColor, path.opacity)
+              });
             } else {
-              paper.utils.setPathOption(path, 'strokeWidth', 0); // Ensure it's ignored later
+              // Ensure it's ignored later.
+              paper.utils.setPathOption(path, {strokeWidth: 0});
               doStroke = false;
             }
             break;
+
           case 4: // Type 4: No fill, no stroke shape (invisible)
             if (settings.strokeNoStrokePaths) {
-              paper.utils.setPathOption(path, 'strokeColor', snapColor(path.strokeColor, path.opacity));
+              paper.utils.setPathOption(path, {
+                strokeColor: snapColor(path.strokeColor, path.opacity)
+              });
             } else {
-              paper.utils.setPathOption(path, 'strokeWidth', 0); // Ensure it's ignored later
+              // Ensure it's ignored later.
+              paper.utils.setPathOption(path, {strokeWidth: 0});
               doStroke = false;
             }
             break;
@@ -164,8 +180,11 @@ module.exports = function(paper) {
             data.color = settings.pathColor;
           }
 
-          paper.utils.setPathOption(path, 'data', data);
-          paper.utils.setPathOption(path, 'strokeWidth', settings.lineWidth);
+          paper.utils.setPathOption(path, {
+            data: data,
+            strokeWidth: settings.lineWidth,
+          });
+
           path.originalOpacity = path.opacity;
           maxLen += paper.utils.getPathLength(path);
         }
@@ -175,7 +194,7 @@ module.exports = function(paper) {
           //path.opacity = 0;
         }
 
-        // Close stroke paths with fill to ensure they fully encompass the filled
+        // Close stroke paths w\fill to ensure they fully encompass the filled
         // color (only when they have a fillable color);
         if (!path.closed && settings.closeFilledPaths) {
           if (hasColor(path.fillColor)) {

--- a/resources/rp_modules/paper.utils.js
+++ b/resources/rp_modules/paper.utils.js
@@ -78,13 +78,17 @@ module.exports = function(paper) {
     },
 
     // Try to set a compound path's option.
-    setPathOption: function(path, option, value) {
-      path[option] = value;
-      if (path.children) {
-        _.forEach(path.children, function(child) {
-          paper.utils.setPathOption(child, option, value);
-        });
-      }
+    setPathOption: function(path, options) {
+      _.forEach(options, function(value, key){
+        path[key] = value;
+        if (path.children) {
+          _.forEach(path.children, function(child) {
+            var opt = {};
+            opt[key] = value;
+            paper.utils.setPathOption(child, opt);
+          });
+        }
+      });
     },
 
     // Return an integer for the "color type" of a path, defining how it's

--- a/resources/rp_modules/paper.utils.js
+++ b/resources/rp_modules/paper.utils.js
@@ -65,6 +65,28 @@ module.exports = function(paper) {
       return false;
     },
 
+    // Try to get a compound path's length.
+    getPathLength: function(path) {
+      if (_.isNumber(path.length)) return path.length;
+      var len = 0;
+      if (path.children) {
+        _.forEach(path.children, function(child) {
+          len += paper.utils.getPathLength(child);
+        });
+      }
+      return len;
+    },
+
+    // Try to set a compound path's option.
+    setPathOption: function(path, option, value) {
+      path[option] = value;
+      if (path.children) {
+        _.forEach(path.children, function(child) {
+          paper.utils.setPathOption(child, option, value);
+        });
+      }
+    },
+
     // Return an integer for the "color type" of a path, defining how it's
     // attributes combine to make it either filled, stroked, etc.
     getPathColorType: function(path) {


### PR DESCRIPTION
Apparently when setting a value on a compound path, it does not set the value on any of its children, so only the _very first_ compound path child in `nothing.svg` was being correctly recognized, but as soon as it finished, it couldn't read the data that simply wasn't there. To compound issues, you also can't read the `length` of a compound path. So I've built two new recursive util functions to allow for setting any path value on a compound path/group and all its children, and to do the same for checking the length.

...at this point I'm suspecting that if you have a compound path with more than one color, it will not be correctly parsed.. but hey, incremental improvements, right? :stuck_out_tongue_winking_eye: 