### PR TITLE
Use npm to build node-serialport for Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,24 +115,20 @@ which will have the command line tools required for builds.
 as source to be built on the target machines, so you shouldn't have to install
 anything new for this at all.
 
-#### Building natively for Electron with `electron-rebuild`
- 0. Pull down/clone your fork of the RoboPaint repository with git (or just
+#### Building natively for Electron
+1. Pull down/clone your fork of the RoboPaint repository with git (or just
   download a zip of the files).
- 1. In your terminal/command line interface, go to that folder and run
- `npm install` to install dependencies, then `npm install electron-rebuild`
- to install electron-rebuild locally.
-   * This will have built the node-serialport for node, but we actually need
-the binary created with electron headers, so:
-   * First delete the compiled `serialport.node` file in
-`node_modules/cncserver/node_modules/serialport/build/Release/`, or whever `npm`
-happens to put the serialport module.
-   * Mac/Linux: run `node_modules/.bin/electron-rebuild`
-   * Windows: run `node_modules\.bin\electron-rebuild.cmd`
-   * You may see some errors, but it should re-compile everything that needs it.
-4. That's it! You should now be installed and ready to hack. To update CNC server
-just run `npm install cncserver` from the project root and it should pull from
-the latest master, and you'll likely need to re-run `electron-rebuild`, or the
-fix script via `npm run fix-serialport`.
+
+  2. In your terminal/command line interface, go to that folder and run
+  `npm install` to install dependencies, if there is not a prebuilt serialport
+  module for your architecture npm will try to build serialport for Electron.
+  You may see some errors, but it should re-compile everything that needs it.
+
+  3. That's it! You should now be installed and ready to hack. To update CNC server
+  just run `npm install cncserver` from the project root and it should pull from
+  the latest master, and you'll likely need to rebuild serialport for Electron
+  with `npm run fix-serialport`.
+
 
 ### Running RoboPaint from source
 * Assuming this is all working, get yourself to the root of the repo and simply

--- a/resources/scripts/root/fix-serialport.js
+++ b/resources/scripts/root/fix-serialport.js
@@ -1,6 +1,8 @@
 /**
  * @file Helper program to assist in installing the correct OS specific compiled
  * binary for node-serialport.
+ * This will only be run by the postinstall trigger if `npm install` is run with
+ * no packages. `npm install` will run this, `npm install serialport` will not.
  */
 
 var fs = require('fs-plus');

--- a/resources/scripts/root/fix-serialport.js
+++ b/resources/scripts/root/fix-serialport.js
@@ -29,7 +29,8 @@ if (fs.existsSync(binFile)) {
   var npmArgs = [
     'install', '--runtime=electron',
     '--disturl=https://atom.io/download/atom-shell', '--target=1.0.2',
-    'serialport'];
+    'serialport'
+  ];
 
   console.log('Unable to place pre-compiled serialport binary, unupported OS/architechture.');
   console.log(`Using npm to build serialport for Electron on ${dir}.`);

--- a/resources/scripts/root/fix-serialport.js
+++ b/resources/scripts/root/fix-serialport.js
@@ -30,7 +30,7 @@ if (fs.existsSync(binFile)) {
   console.log('> npm install serialport');
 
   // Envrionment vars we need to set to make npm (, node-gyp, and node-pre-gyp)
-  // use the correct Electron to build native modules for
+  // build native modules for Electron
   var npmConfig = {
     npm_config_runtime: 'electron',
     npm_config_disturl: 'https://atom.io/download/atom-shell',

--- a/resources/scripts/root/fix-serialport.js
+++ b/resources/scripts/root/fix-serialport.js
@@ -24,20 +24,17 @@ if (fs.existsSync(binFile)) {
     console.error('Problem placing pre-compiled binary.', e);
   }
 } else {
+  var npmArgs = [
+    'install', '--runtime=electron',
+    '--disturl=https://atom.io/download/atom-shell', '--target=1.0.2',
+    'serialport'];
+
   console.log('Unable to place pre-compiled serialport binary, unupported OS/architechture.');
-  console.log('Using npm to build serialport for Electron locally.');
+  console.log(`Using npm to build serialport for Electron on ${dir}.`);
   console.log('This will fail if you do not have the necessary build tools.');
-  console.log('> npm install serialport');
+  console.log(`> npm ${npmArgs.join(' ')}`);
 
-  // Envrionment vars we need to set to make npm (, node-gyp, and node-pre-gyp)
-  // build native modules for Electron
-  var npmConfig = {
-    npm_config_runtime: 'electron',
-    npm_config_disturl: 'https://atom.io/download/atom-shell',
-    npm_config_target: '1.0.2'
-  }
-
-  var npmCmd = spawn('npm', ['install', 'serialport'], {env: Object.assign({} , process.env, npmConfig)});
+  var npmCmd = spawn('npm', npmArgs);
 
   npmCmd.stdout.pipe(process.stdout);
   npmCmd.stderr.pipe(process.stderr);


### PR DESCRIPTION
Replaces `electron-rebuild` with npm to build node-serialport for Electron. This will try to build serialport for Electron if a prebuilt binary is not found automatically.