### PR TITLE
Remove node native runner CNCServer option from settings

### DIFF
--- a/resources/_i18n/robopaint.en-US.json
+++ b/resources/_i18n/robopaint.en-US.json
@@ -265,8 +265,6 @@
     "output": {
       "skipwhite": "Skip White Paint",
       "skipwhiteinfo": "When your media settings (paint colors) contain white, ignore any paths that would be painted in that color. You may want to turn this off when painting on a background that is not white.",
-      "nativerunner": "Use Native CNCServer Runner",
-      "nativerunnerinfo": "If enabled, CNCServer will stream commands via a separate node.js process that will be immune to Electron's background limitations. **Change requires App restart, and node.js installed globally.**",
       "optimize": "Optimize path order",
       "optimizeinfo": "If enabled, all automatic painting paths (fill and stroke) will be reordered according to color and proximity to previous path end. Paths will even be reversed to ensure lowest distance between work, but can take a very strange path if working with multiple lines of text.",
       "generaltitle": "General",

--- a/resources/_i18n/robopaint.en-US.json
+++ b/resources/_i18n/robopaint.en-US.json
@@ -265,8 +265,8 @@
     "output": {
       "skipwhite": "Skip White Paint",
       "skipwhiteinfo": "When your media settings (paint colors) contain white, ignore any paths that would be painted in that color. You may want to turn this off when painting on a background that is not white.",
-      "nativerunner": "Use Native CNCServer Runner",
-      "nativerunnerinfo": "If enabled, CNCServer will stream commands via a separate node.js process that will be immune to Electron's background limitations. **Change requires App restart, and node.js installed globally.**",
+      "prefill": "Prefill buffer",
+      "prefillinfo": "If enabled, all batch commands on supporting modes will be sent before the robot begins work. This should eliminate stuttering on start, though you have to wait longer before your work begins printing.",
       "optimize": "Optimize path order",
       "optimizeinfo": "If enabled, all automatic painting paths (fill and stroke) will be reordered according to color and proximity to previous path end. Paths will even be reversed to ensure lowest distance between work, but can take a very strange path if working with multiple lines of text.",
       "generaltitle": "General",

--- a/resources/_i18n/robopaint.en-US.json
+++ b/resources/_i18n/robopaint.en-US.json
@@ -265,8 +265,8 @@
     "output": {
       "skipwhite": "Skip White Paint",
       "skipwhiteinfo": "When your media settings (paint colors) contain white, ignore any paths that would be painted in that color. You may want to turn this off when painting on a background that is not white.",
-      "prefill": "Prefill buffer",
-      "prefillinfo": "If enabled, all batch commands on supporting modes will be sent before the robot begins work. This should eliminate stuttering on start, though you have to wait longer before your work begins printing.",
+      "nativerunner": "Use Native CNCServer Runner",
+      "nativerunnerinfo": "If enabled, CNCServer will stream commands via a separate node.js process that will be immune to Electron's background limitations. **Change requires App restart, and node.js installed globally.**",
       "optimize": "Optimize path order",
       "optimizeinfo": "If enabled, all automatic painting paths (fill and stroke) will be reordered according to color and proximity to previous path end. Paths will even be reversed to ensure lowest distance between work, but can take a very strange path if working with multiple lines of text.",
       "generaltitle": "General",

--- a/resources/main.js
+++ b/resources/main.js
@@ -484,25 +484,21 @@ function startSerial(){
   setMessage('status.start', 'loading');
 
   try {
-    // Load the CNCServer serial runner in a webview if not using node native...
-    if (!robopaint.settings.usenativerunner) {
-      var $runner = $('<webview>').attr({
-        border: 0,
-        class: 'hide',
-        nodeintegration: 'true',
-        src: '../node_modules/cncserver/runner/runner.html',
-        disablewebsecurity: 'true',
-      }).appendTo('body');
+    // Load the CNCServer serial runner in a webview...
+    var $runner = $('<webview>').attr({
+      border: 0,
+      class: 'hide',
+      nodeintegration: 'true',
+      src: '../node_modules/cncserver/runner/runner.html',
+      disablewebsecurity: 'true',
+    }).appendTo('body');
 
-      // Report runner messages direct to the main console.
-      $runner[0].addEventListener('console-message', function(e) {
-        console.log('RUNNER:', e.message);
-      });
-    }
+    $runner[0].addEventListener('console-message', function(e) {
+      console.log('RUNNER:', e.message);
+    });
 
     cncserver.start({
       botType: robopaint.currentBot.type,
-      localRunner: robopaint.settings.usenativerunner,
       success: function() {
         setMessage('status.found');
       },

--- a/resources/main.js
+++ b/resources/main.js
@@ -484,25 +484,22 @@ function startSerial(){
   setMessage('status.start', 'loading');
 
   try {
-    // Load the CNCServer serial runner in a webview if not using node native...
-    if (!robopaint.settings.usenativerunner) {
-      var $runner = $('<webview>').attr({
-        border: 0,
-        class: 'hide',
-        nodeintegration: 'true',
-        src: '../node_modules/cncserver/runner/runner.html',
-        disablewebsecurity: 'true',
-      }).appendTo('body');
+    // Load the CNCServer serial runner in a webview...
+    var $runner = $('<webview>').attr({
+      border: 0,
+      class: 'hide',
+      nodeintegration: 'true',
+      src: '../node_modules/cncserver/runner/runner.html',
+      disablewebsecurity: 'true',
+    }).appendTo('body');
 
-      // Report runner messages direct to the main console.
-      $runner[0].addEventListener('console-message', function(e) {
-        console.log('RUNNER:', e.message);
-      });
-    }
+    // Report runner messages direct to the main console.
+    $runner[0].addEventListener('console-message', function(e) {
+      console.log('RUNNER:', e.message);
+    });
 
     cncserver.start({
       botType: robopaint.currentBot.type,
-      localRunner: robopaint.settings.usenativerunner,
       success: function() {
         setMessage('status.found');
       },

--- a/resources/main.js
+++ b/resources/main.js
@@ -484,21 +484,25 @@ function startSerial(){
   setMessage('status.start', 'loading');
 
   try {
-    // Load the CNCServer serial runner in a webview...
-    var $runner = $('<webview>').attr({
-      border: 0,
-      class: 'hide',
-      nodeintegration: 'true',
-      src: '../node_modules/cncserver/runner/runner.html',
-      disablewebsecurity: 'true',
-    }).appendTo('body');
+    // Load the CNCServer serial runner in a webview if not using node native...
+    if (!robopaint.settings.usenativerunner) {
+      var $runner = $('<webview>').attr({
+        border: 0,
+        class: 'hide',
+        nodeintegration: 'true',
+        src: '../node_modules/cncserver/runner/runner.html',
+        disablewebsecurity: 'true',
+      }).appendTo('body');
 
-    $runner[0].addEventListener('console-message', function(e) {
-      console.log('RUNNER:', e.message);
-    });
+      // Report runner messages direct to the main console.
+      $runner[0].addEventListener('console-message', function(e) {
+        console.log('RUNNER:', e.message);
+      });
+    }
 
     cncserver.start({
       botType: robopaint.currentBot.type,
+      localRunner: robopaint.settings.usenativerunner,
       success: function() {
         setMessage('status.found');
       },

--- a/resources/main.settings.inc.html
+++ b/resources/main.settings.inc.html
@@ -287,6 +287,12 @@
       </div>
 
       <div>
+        <input type="checkbox" id="prefillbuffer"/>
+        <label for="prefillbuffer" data-i18n>settings.output.prefill</label>
+        <aside data-i18n>settings.output.prefillinfo</aside>
+      </div>
+
+      <div>
         <input type="checkbox" id="optimizepath"/>
         <label for="optimizepath" data-i18n>settings.output.optimize</label>
         <aside data-i18n>settings.output.optimizeinfo</aside>
@@ -486,12 +492,6 @@
       <label for="httplocalonly" data-i18n>settings.advanced.httplocalonly.title</label>
       <input type="checkbox" id="httplocalonly"/>
       <aside data-i18n>settings.advanced.httplocalonly.detail</aside>
-    </div>
-
-    <div>
-      <input type="checkbox" id="usenativerunner"/>
-      <label for="usenativerunner" data-i18n>settings.output.nativerunner</label>
-      <aside data-i18n>settings.output.nativerunnerinfo</aside>
     </div>
   </fieldset>
 </div>

--- a/resources/main.settings.inc.html
+++ b/resources/main.settings.inc.html
@@ -287,12 +287,6 @@
       </div>
 
       <div>
-        <input type="checkbox" id="prefillbuffer"/>
-        <label for="prefillbuffer" data-i18n>settings.output.prefill</label>
-        <aside data-i18n>settings.output.prefillinfo</aside>
-      </div>
-
-      <div>
         <input type="checkbox" id="optimizepath"/>
         <label for="optimizepath" data-i18n>settings.output.optimize</label>
         <aside data-i18n>settings.output.optimizeinfo</aside>
@@ -492,6 +486,12 @@
       <label for="httplocalonly" data-i18n>settings.advanced.httplocalonly.title</label>
       <input type="checkbox" id="httplocalonly"/>
       <aside data-i18n>settings.advanced.httplocalonly.detail</aside>
+    </div>
+
+    <div>
+      <input type="checkbox" id="usenativerunner"/>
+      <label for="usenativerunner" data-i18n>settings.output.nativerunner</label>
+      <aside data-i18n>settings.output.nativerunnerinfo</aside>
     </div>
   </fieldset>
 </div>

--- a/resources/main.settings.inc.html
+++ b/resources/main.settings.inc.html
@@ -487,12 +487,6 @@
       <input type="checkbox" id="httplocalonly"/>
       <aside data-i18n>settings.advanced.httplocalonly.detail</aside>
     </div>
-
-    <div>
-      <input type="checkbox" id="usenativerunner"/>
-      <label for="usenativerunner" data-i18n>settings.output.nativerunner</label>
-      <aside data-i18n>settings.output.nativerunnerinfo</aside>
-    </div>
   </fieldset>
 </div>
 

--- a/resources/scripts/main.settings.js
+++ b/resources/scripts/main.settings.js
@@ -75,7 +75,7 @@ function loadSettings() {
     fillocclusionfills: 1,
 
     skipwhite: 1,
-    usenativerunner: 0,
+    prefillbuffer: 1,
     optimizepath: 1
   };
 

--- a/resources/scripts/main.settings.js
+++ b/resources/scripts/main.settings.js
@@ -75,7 +75,6 @@ function loadSettings() {
     fillocclusionfills: 1,
 
     skipwhite: 1,
-    usenativerunner: 0,
     optimizepath: 1
   };
 

--- a/resources/scripts/main.settings.js
+++ b/resources/scripts/main.settings.js
@@ -75,7 +75,7 @@ function loadSettings() {
     fillocclusionfills: 1,
 
     skipwhite: 1,
-    prefillbuffer: 1,
+    usenativerunner: 0,
     optimizepath: 1
   };
 


### PR DESCRIPTION
This option has caused problems for users at least two times, and the native runner has no significant performance benefit.

This reverts commit [c6deca8](https://github.com/evil-mad/robopaint/commit/c6deca82c1591d5d878e238c02e0d15689df3b87), which added the native runner option.